### PR TITLE
services/oauth2/access_token_validation_service#sufficent_scope?, scopes...

### DIFF
--- a/app/services/oauth2/access_token_validation_service.rb
+++ b/app/services/oauth2/access_token_validation_service.rb
@@ -31,6 +31,7 @@ module Oauth2::AccessTokenValidationService
       else
         # If there are scopes required, then check whether
         # the set of authorized scopes is a superset of the set of required scopes
+        scopes.map! &:to_s
         required_scopes = Set.new(scopes)
         authorized_scopes = Set.new(token.scopes)
 


### PR DESCRIPTION
services/oauth2/access_token_validation_service#sufficent_scope?, scopes array should be string.

When comparing two sets, they mismatch and it shows below.

``` ruby
#<Set: {:red}>
#<Set: {"red"}>
```

This fix will force scopes array to string.
